### PR TITLE
Let requests manage param formatting, style cleanup

### DIFF
--- a/packs/webpagetest/actions/lib/webpagetest.py
+++ b/packs/webpagetest/actions/lib/webpagetest.py
@@ -10,7 +10,8 @@ def list_locations(wpt_url, key=None):
     params = {'f': 'json'}
     if key:
         params['k'] = key
-    request = requests.get("%s/getLocations.php" % wpt_url, params=params)
+    request = requests.get("{0}/getLocations.php".format(wpt_url),
+                           params=params)
     locations = request.json()['data']
     return sorted(locations.keys())
 
@@ -24,7 +25,7 @@ def request_test(domain, location_id, wpt_url, key=None):
     if key:
         params['k'] = key
 
-    request = requests.get("%s/runtest.php" % wpt_url, params=params)
+    request = requests.get("{0}/runtest.php".format(wpt_url), params=params)
     return request.json()
 
 
@@ -37,7 +38,7 @@ def get_test_results(test_id, wpt_url, key=None):
     if key:
         params['k'] = key
 
-    request = requests.get("%s/jsonResult.php" % wpt_url, params=params)
+    request = requests.get("{0}/jsonResult.php".format(wpt_url), params=params)
     return request.json()
 
 
@@ -51,9 +52,10 @@ def test_random_location(domain, wpt_url, key=None):
     try:
         return test['data']['userUrl']
     except KeyError:
-        return "Error: %s" % test
+        return "Error: {0}".format(test)
 
 if __name__ == "__main__":
-    print "Test results: %s" % (
-        test_random_location("http://example.com", "http://webpagetest.org",
+    print "Test results: {0}".format(
+        test_random_location("http://example.com",
+                             "http://webpagetest.org",
                              "your-api-key-here"))

--- a/packs/webpagetest/actions/lib/webpagetest.py
+++ b/packs/webpagetest/actions/lib/webpagetest.py
@@ -10,13 +10,9 @@ def list_locations(wpt_url, key=None):
     params = {'f': 'json'}
     if key:
         params['k'] = key
-    r = requests.get("%s/getLocations.php" % wpt_url, params=params)
-    locations = r.json()['data']
-
-    result = []
-    for location, _ in sorted(locations.items()):
-        result.append(location)
-    return result
+    request = requests.get("%s/getLocations.php" % wpt_url, params=params)
+    locations = request.json()['data']
+    return sorted(locations.keys())
 
 
 def request_test(domain, location_id, wpt_url, key=None):
@@ -28,8 +24,8 @@ def request_test(domain, location_id, wpt_url, key=None):
     if key:
         params['k'] = key
 
-    r = requests.get("%s/runtest.php" % wpt_url, params=params)
-    return r.json()
+    request = requests.get("%s/runtest.php" % wpt_url, params=params)
+    return request.json()
 
 
 def get_test_results(test_id, wpt_url, key=None):
@@ -41,8 +37,8 @@ def get_test_results(test_id, wpt_url, key=None):
     if key:
         params['k'] = key
 
-    r = requests.get("%s/jsonResult.php" % wpt_url, params=params)
-    return r.json()
+    request = requests.get("%s/jsonResult.php" % wpt_url, params=params)
+    return request.json()
 
 
 def test_random_location(domain, wpt_url, key=None):


### PR DESCRIPTION
- Removes string formatting for request parameters. Uses `requests` use of the `params` dict.
- Flake8/Pylint cleanup based on OpenStack `HACKING` style guidelines.
- Slack code was for our hackday testing. Dropping it.

You should assume that none of this has been tested and CYA before you merge ;) 
